### PR TITLE
feat: Format research summary and proposal as HTML

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -349,12 +349,12 @@ class ChemistryResearchApp {
         
         // Populate summary
         if (this.summaryContent) {
-            this.summaryContent.textContent = result.summary;
+            this.summaryContent.innerHTML = this.formatProposalText(result.summary);
         }
         
         // Populate proposal
         if (this.proposalContent) {
-            this.proposalContent.textContent = result.proposal;
+            this.proposalContent.innerHTML = this.formatProposalText(result.proposal);
         }
         
         // Update metadata


### PR DESCRIPTION
The research summary and proposal were previously being rendered as plain text, ignoring any markdown-style formatting from the backend.

This change modifies the `displayResearchResults` function in `static/js/app.js` to:
- Use `innerHTML` instead of `textContent` to render the content.
- Utilize the existing `formatProposalText` helper function to convert the markdown-like text to proper HTML before displaying it.

This ensures that formatting such as headers, bold text, and paragraphs are correctly rendered in the UI.